### PR TITLE
chore: disable access log

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -7,6 +7,7 @@ events {
 }
 
 http {
+    access_log off;
     map $http_x_forwarded_for $client_ip {
     # Default to $remote_addr if X-Forwarded-For is empty
     "" $remote_addr;


### PR DESCRIPTION
Denne nginxen produserer etterhvert ganske mye logg, fra helt legitim trafikk.
Vi bruker normalt loadbalancer-loggen i GCP til å undersøke trafikklogg, kan heller skrus på ved behov.

Denne skrur bare av logger relatert til requests, vanlige errors beholdes
